### PR TITLE
Added missing safecheck for body_markdown.

### DIFF
--- a/lib/how2.js
+++ b/lib/how2.js
@@ -150,9 +150,22 @@ function magic(text, lang) {
     }
 
     function selectedAnswer(titles, answers, index, remember) {
-        var markdown = utils.toEscapedMarkdown(answers[index].body_markdown);
+        var markdown;
+        var title;
+        
+        if (typeof answers === 'object' && typeof answers[index] !== 'undefined') {
+            markdown = utils.toEscapedMarkdown(answers[index].body_markdown);
+        } else {
+            console.log('No answers found.');
+            return;
+        }
 
-        var title = titles[index];
+        if (typeof titles === 'object' && typeof titles[index] !== 'undefined') {
+            title = titles[index];
+        } else {
+            title = 'Untitled answer';
+        }
+        
         console.log(colors.underline.green(title+'\n'));
         // console.log(colors.blue(Array(title.length).join('=')));
         console.log(markdown);


### PR DESCRIPTION
Query:

```shell
how2 js node list to array
Cannot fetch answers from Stackoverflow.
TypeError: Cannot read property 'body_markdown' of undefined
```

Results in an unhandled error, that may not be clear for the user and is quite not elegant (also the problem is not with fetching itself, as the script tells us, but with the amount of found answers).

Added missing safecheck for `body_markdown`.
Prevents the script from failing, when no answer is found or the answer has no title.

Followed @danielkop branch naming for readability :wink: 