### PR TITLE
fixing array index errors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,9 +41,17 @@ function parseStackoverflowQuestionId(link) {
         var re = /.*\/\/(.*).stackexchange.com\/questions\/(\d+)\//;
         var matches = re.exec(link);
         // console.log(matches)
+        var site = null,
+            questionId = null;
+        if (matches && matches[1]){
+            site = matches[1];
+        }
+        if (matches && matches[2]){
+            questionId = matches[2];
+        }
         return {
-            site: matches[1],
-            questionId: matches[2]
+            site: site,
+            questionId: questionId
         };
     }
     else return null;


### PR DESCRIPTION
Just to fix this little issue

```
# ./bin/how2 pip                                                                                               
/Users/c5212221/workspace/how2/lib/utils.js:45
            site: matches[1],
                         ^

TypeError: Cannot read property '1' of null
    at Object.parseStackoverflowQuestionId (/Users/c5212221/workspace/how2/lib/utils.js:45:26)
    at /Users/c5212221/workspace/how2/lib/how2.js:20:32
    at /Users/c5212221/workspace/how2/lib/how2.js:194:9
    at /Users/c5212221/workspace/how2/lib/how2.js:108:9
    at Request._callback (/Users/c5212221/workspace/how2/node_modules/google/lib/google.js:85:7)
    at Request.self.callback (/Users/c5212221/workspace/how2/node_modules/request/request.js:199:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (/Users/c5212221/workspace/how2/node_modules/request/request.js:1036:10)
    at emitOne (events.js:82:20)
```

```
./bin/how2 pip          
{ error_id: 404,
  error_message: 'no method found with this name',
  error_name: 'no_method' }
```
I don't know what is the best way to show this error, I've only fixed the issue. 
Regards
