### PR TITLE
Remove ES6 template strings for node 0.10+ compatibility

### DIFF
--- a/test/strip-stack-overflow.js
+++ b/test/strip-stack-overflow.js
@@ -3,7 +3,7 @@ var fun = require('../lib/utils').stripStackOverflow;
 
 describe('stripStackOverflow', function() {
     it('should not strip -f parameters in the title', function () {
-        var title = `monitoring - How does the "tail" command's "-f" parameter ...`;
+        var title = 'monitoring - How does the "tail" command\'s "-f" parameter ...';
         assert.equal(fun(title), title);
     });
     it('should strip Unix & Linux Stack Exchange', function() {


### PR DESCRIPTION
I'm all for ES6, but I think it's not worth it to lose compatibility to older versions just for template strings which are available just as of node 4. If you do want to use ES6 features, better use the "engines" field in package.json to ensure node version compatibility during installation.