### PR TITLE
Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # how2: stackoverflow from the terminal
 
+[![NPM Version](https://img.shields.io/npm/v/how2.svg?style=flat)](https://npmjs.org/package/how2)
+[![Dependency Status](https://david-dm.org/santinic/how2.svg)](https://david-dm.org/santinic/how2)
+[![devDependency Status](https://david-dm.org/santinic/how2/dev-status.svg)](https://david-dm.org/santinic/how2#info=devDependencies)
+
 how2 finds the simplest way to do something in a unix shell.
 It's like `man`, but you can query it in natural language:
 


### PR DESCRIPTION
Added badges for npm version (which is also link to the npm page) and to dependencies status at david-dm.org.

Can be viewed [here](https://github.com/danyshaanan/how2/tree/badges).

The 'insecure' dependency is fixed with #48