### PR TITLE
Convert <KBD>key</KBD> HTML tags in markdown to [ key ]

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -115,7 +115,7 @@ function showGoogleList(links, titles, callback) {
 }
 
 function makeTitleForAnswer(answer) {
-    var withColors = utils.marked(answer.body_markdown);
+    var withColors = utils.kbdTagFix(utils.marked(answer.body_markdown));
 
     var lines = withColors.split('\n');
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@ var _ = require('lodash');
 var htmlentities = require('ent');
 var marked = require('marked');
 var TerminalRenderer = require('marked-terminal');
+var colors = require('colors');
 
 marked.setOptions({
     // Define custom renderer
@@ -58,7 +59,8 @@ function isValidGoogleLink(link) {
 
 function kbdTagFix(escapedMarkdown)
 {
-    return escapedMarkdown.split("<kbd>").join("[ ").split("</kbd>").join(" ]");
+    var kbdEncasedGlobalCaseInsesitive = /<KBD>(.*?)<\/KBD>/gi;
+    return escapedMarkdown.replace(kbdEncasedGlobalCaseInsesitive, colors.gray("[ "+colors.white.bold("$1")+" ]"));
 }
 
 function toEscapedMarkdown(markdown) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,8 +56,13 @@ function isValidGoogleLink(link) {
     return parseStackoverflowQuestionId(link.link) !== null;
 }
 
+function kbdTagFix(escapedMarkdown)
+{
+    return escapedMarkdown.split("<kbd>").join("[ ").split("</kbd>").join(" ]");
+}
+
 function toEscapedMarkdown(markdown) {
-     return htmlentities.decode(marked(markdown));
+     return kbdTagFix(htmlentities.decode(marked(markdown)));
 }
 
 module.exports = {
@@ -65,5 +70,6 @@ module.exports = {
     stripStackOverflow: stripStackOverflow,
     isValidGoogleLink: isValidGoogleLink,
     toEscapedMarkdown: toEscapedMarkdown,
+    kbdTagFix : kbdTagFix,
     marked: marked
 };


### PR DESCRIPTION
Should solve #25 
Simple find / replace on <kbd> and </kbd> and replaced with "[ " and " ]".
Added to both toEscapedMarkdown and to makeTitleForAnswer functions.
Also added color to the keys to avoid confusion when converting <KBD>]</KBD> to [ ] ] 

Tested with "how2 -l vi indent multiple lines" on windows