### PR TITLE
Add a GitHub Pages site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docs/dist
 node_modules
 npm-debug.log
 .DS_Store

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -1,0 +1,15 @@
+.l-title {
+  padding-right: 25px;
+}
+
+.l-title,
+.l-title:active,
+.l-title:hover,
+.l-title:visited {
+  color: #fff;
+  text-decoration: none;
+}
+
+.max-width {
+  max-width: 1000px;
+}

--- a/docs/assets/main.ejs
+++ b/docs/assets/main.ejs
@@ -1,0 +1,66 @@
+<!doctype html>
+<html class="no-js" lang="">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title><%= title %></title>
+    <meta name="description" content="Static site generator for GitHub Pages">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons|Roboto:300,400,500,700">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-pink.min.css">
+    <link rel="stylesheet" href="/main.css">
+    <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
+</head>
+<body>
+<div class="mdl-layout__container">
+    <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+        <div class="mdl-layout-icon"></div>
+        <header class="mdl-layout__header">
+            <div class="mdl-layout__header-row">
+                <a class="mdl-layout-title l-title" href="/">how2</a>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link" href="/">About</a>
+                    <a class="mdl-navigation__link" href="https://github.com/santinic/how2">GitHub</a>
+                </nav>
+                <div class="mdl-layout-spacer"></div>
+                <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable mdl-textfield--floating-label mdl-textfield--align-right">
+                    <label class="mdl-button mdl-js-button mdl-button--icon" for="fixed-header-drawer-exp">
+                        <i class="material-icons">search</i>
+                    </label>
+                    <div class="mdl-textfield__expandable-holder">
+                        <input class="mdl-textfield__input" type="text" name="sample" id="fixed-header-drawer-exp">
+                    </div>
+                </div>
+            </div>
+        </header>
+        <div class="mdl-layout__drawer">
+            <span class="mdl-layout__title">Menu</span>
+            <nav class="mdl-navigation">
+                <a class="mdl-navigation__link" href="/">About</a>
+                <a class="mdl-navigation__link" href="https://github.com/santinic/how2">GitHub</a>
+            </nav>
+        </div>
+        <main class="mdl-layout__content">
+            <div class="mdl-grid max-width">
+                <%- content %>
+            </div>
+            <footer class="mdl-mini-footer">
+                <div class="mdl-grid max-width">
+                    <div class="mdl-mini-footer__middle-section">
+                        <ul class="mdl-mini-footer__link-list">
+                            <li>Maintained by <a href="https://twitter.com/santinic">@santinic</a> with help from <a href="https://github.com/santinic/how2/graphs/contributors">contributors</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </footer>
+        </main>
+    </div>
+</div>
+<script>
+    window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+    ga('create','UA-XXXXXX-XX','auto');ga('send','pageview')
+</script>
+<script src="https://www.google-analytics.com/analytics.js" async defer></script>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,86 @@
+---
+title: how2 - stackoverflow from the terminal
+---
+# how2: stackoverflow from the terminal
+
+ow2 finds the simplest way to do something in a unix shell.
+It's like `man`, but you can query it in natural language:
+
+![Demo of using how2](https://raw.githubusercontent.com/santinic/how2/master/img/demo.gif)
+
+## Install
+You can install it via npm:
+
+`npm install -g how2`
+
+if it gives you EACCES errors, [you need to fix npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions). Or you can just use `sudo npm install -g how2` if you don't care.
+
+#### If you don't have npm
+Then [just install NodeJS](https://nodejs.org).
+
+#### On Ubuntu
+Install node: `sudo apt-get install nodejs npm`
+
+Make a symlink: `ln -s /usr/bin/nodejs /usr/bin/node`
+
+Then install how2: `npm install -g how2`
+
+#### On Mac
+Install node with brew: `brew install node`.
+
+If you don't have brew, [download nodejs from here](https://nodejs.org)
+
+Then install how2: `npm install -g how2`
+
+#### If you get "/usr/bin/env: node: No such file or directory"
+Your Linux distro (like Ubuntu) probably uses "nodejs" instead of "node".
+
+Make a symlink and it should work:
+```ln -s /usr/bin/nodejs /usr/bin/node```
+
+## Usage
+If you don't specify a language **it defaults to Bash** unix command line.
+how2 tries to give you immediately the most likely answer:
+
+![how2 unzip bz2](https://raw.githubusercontent.com/santinic/how2/master/img/bz2.png)
+
+After that you can press SPACE to go to the interactive mode, where you can choose a different stackoverflow question/answer.
+
+![how2 interactive mode](https://raw.githubusercontent.com/santinic/how2/master/img/interactive.png)
+
+![how2 interactive mode 2](https://raw.githubusercontent.com/santinic/how2/master/img/interactive2.png)
+
+
+You can use `-l lang` to find answers for other languages:
+
+![-l python](https://raw.githubusercontent.com/santinic/how2/master/img/python.png)
+
+## Copy-Paste with mouse
+When you are in "interactive mode" (after you press SPACE), if you want to copy-paste more than one line you can use block-select:
+
+**With Ubuntu try holding `Ctrl+Alt` before you select, or `Alt+Cmd` if you're in iTerm on Mac.**
+
+(thanks to @danielkop for this suggestion).
+
+## Can i use it behind Proxy ?
+Yes, you need to use `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
+
+For example, you could alias the proxy seetings in your `~/.bash_profile`:
+
+`alias how2="HTTPS_PROXY='your_proxy:8888' how2"`
+
+## How does it work?
+It uses Google and Stackoverflow APIs, because Stackoverflow search on its own doesn't
+works as well.
+
+
+## Why?
+Because I can never remember how to do certain things. And reading man pages always takes too long.
+
+![XKCD](http://imgs.xkcd.com/comics/tar.png)
+
+Taken from https://xkcd.com/1168/
+
+
+## TODO
+* Add automatic copy/paste from -i to command line

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "scripts": {
     "test": "mocha test",
+    "docs": "easystatic start docs",
+    "docs:build": "easystatic build docs",
+    "docs:deploy": "easystatic deploy docs --repo=santinic/how2",
     "start": "./bin/how2 concatenate two files"
   },
   "dependencies": {


### PR DESCRIPTION
1. Create an orphan [gh-pages branch](https://help.github.com/articles/creating-project-pages-manually/)
2. `npm install -g easystatic` - installs [Easystatic](https://easystatic.com) site generator, optimized for GH Pages sites
3. `npm run docs` - generates a static site from `*.md` files in the `docs` folder and launches it in a browser with "live reload" enabled (via [Browsersync](https://browsersync.io/))
4. `npm run docs:deploy` - pushes the generated static site to `gh-pages` branch

P.S.: I created [this utility](https://github.com/easystatic/easystatic) for my own OSS projects and though it might be helpful for you as well.
