### PR TITLE
Pressing 'b' while viewing an answer now opens it in the browser

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -206,6 +206,10 @@ function showAnswer(answer) {
         screen.render();
     });
 
+    answerBox.key(['b'], function(event) {
+        require('openurl').open(answer.link);
+    });
+
     screen.append(answerBox);
     answerBox.focus();
     screen.render();


### PR DESCRIPTION
When viewing a list of answers in interactive mode you can press the 'b' key to open up the highlighted answer in your browser.
I added that very same behaviour for when viewing a single answer in interactive mode.

As an aside: I noticed that at one point `require('openurl')` is wrapped in a try-catch, while a few lines later it isn't. I was unsure which pattern you preferred so I just picked one, but let me know if you prefer the other and I'll gladly update my PR.