### PR TITLE
Changed `devnull` dependency to a specific commit to get fix for EventEmitter issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "blessed": "^0.1.81",
     "colors": "^1.1.2",
-    "devnull": "0.0.12",
+    "devnull": "git+https://github.com/observing/devnull.git#ff99281602feca0cf3bdf0e6d36fedbf1b566523",
     "ent": "^2.2.0",
     "google": "^1.4.0",
     "keypress": "^0.2.1",


### PR DESCRIPTION
This changes the version of `devnull` in `package.json` in order to get the change introduced in [this PR](https://github.com/observing/devnull/pull/4).
This allows `how2` to be used with Node v. 7.x.x and addresses #70.

The reason I set it to a specific commit is because they have yet to to bump their version number allowing a regular update through npm. This is not a great solution, but since they haven't updated their version yet even though the PR went through in June we can't count on them doing it any time soon.

A better long term solution may be to switch to a different module instead of `devnull`.
